### PR TITLE
ALTER TABLE ADD COLUMN with default values.

### DIFF
--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -425,6 +425,7 @@ extern void zsmeta_initmetapage(Relation rel);
 extern Buffer zs_getnewbuf(Relation rel);
 extern BlockNumber zsmeta_get_root_for_attribute(Relation rel, AttrNumber attno, bool for_update, int16 *attlen_p, bool *attbyval_p);
 extern void zsmeta_update_root_for_attribute(Relation rel, AttrNumber attno, Buffer metabuf, BlockNumber rootblk);
+extern void zsmeta_add_root_for_attribute(Relation rel, AttrNumber attno, Page page);
 
 /* prototypes for functions in zedstore_visibility.c */
 extern TM_Result zs_SatisfiesUpdate(ZSBtreeScan *scan, ZSUncompressedBtreeItem *item,

--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -366,6 +366,7 @@ typedef struct ZSBtreeScan
 	AttrNumber	attno;
 	int16		attlen;
 	bool		attbyval;
+	bool        atthasmissing;
 
 	/*
 	 * memory context that should be used for any allocations that go with the scan,
@@ -414,7 +415,7 @@ extern TM_Result zsbt_lock_item(Relation rel, AttrNumber attno, zstid tid,
 			   LockTupleMode lockmode, LockWaitPolicy wait_policy,
 			   TM_FailureData *hufd);
 extern void zsbt_begin_scan(Relation rel, AttrNumber attno, zstid starttid, Snapshot snapshot, ZSBtreeScan *scan);
-extern bool zsbt_scan_next(ZSBtreeScan *scan, Datum *datum, bool *isnull, zstid *tid);
+extern bool zsbt_scan_next(ZSBtreeScan *scan, Datum *datum, bool *isnull, zstid *tid, bool *isvaluemissing);
 extern void zsbt_end_scan(ZSBtreeScan *scan);
 extern zstid zsbt_get_last_tid(Relation rel, AttrNumber attno);
 

--- a/src/test/regress/expected/zedstore.out
+++ b/src/test/regress/expected/zedstore.out
@@ -257,9 +257,10 @@ select * from t_zedcopy;
  10005 | 26 | 36    | 46     | 56
 (12 rows)
 
--- Test for alter table add column force rewrite
+--- Test for alter table add column
 create table t_zaddcol(a int) using zedstore;
 insert into t_zaddcol select * from generate_series(1, 3);
+-- rewrite case
 alter table t_zaddcol add column b int generated always as (a + 1) stored;
 select * from t_zaddcol;
  a | b 
@@ -267,5 +268,25 @@ select * from t_zaddcol;
  1 | 2
  2 | 3
  3 | 4
+(3 rows)
+
+-- fixed length default value stored in catalog
+alter table t_zaddcol add column c int default 3;
+select * from t_zaddcol;
+ a | b | c 
+---+---+---
+ 1 | 2 | 3
+ 2 | 3 | 3
+ 3 | 4 | 3
+(3 rows)
+
+-- variable length default value stored in catalog
+alter table t_zaddcol add column d text default 'abcdefgh';
+select d from t_zaddcol;
+    d     
+----------
+ abcdefgh
+ abcdefgh
+ abcdefgh
 (3 rows)
 

--- a/src/test/regress/sql/zedstore.sql
+++ b/src/test/regress/sql/zedstore.sql
@@ -103,8 +103,15 @@ COPY t_zedcopy (a, b, c, d, e) from stdin;
 
 select * from t_zedcopy;
 
--- Test for alter table add column force rewrite
+--- Test for alter table add column
 create table t_zaddcol(a int) using zedstore;
 insert into t_zaddcol select * from generate_series(1, 3);
+-- rewrite case
 alter table t_zaddcol add column b int generated always as (a + 1) stored;
 select * from t_zaddcol;
+-- fixed length default value stored in catalog
+alter table t_zaddcol add column c int default 3;
+select * from t_zaddcol;
+-- variable length default value stored in catalog
+alter table t_zaddcol add column d text default 'abcdefgh';
+select d from t_zaddcol;

--- a/src/test/regress/sql/zedstore.sql
+++ b/src/test/regress/sql/zedstore.sql
@@ -115,3 +115,12 @@ select * from t_zaddcol;
 -- variable length default value stored in catalog
 alter table t_zaddcol add column d text default 'abcdefgh';
 select d from t_zaddcol;
+
+create table t_zaddcol_insert (a int) using zedstore;
+insert into t_zaddcol_insert values (1);
+alter table t_zaddcol_insert add column b int default 3;
+select * from t_zaddcol_insert;
+insert into t_zaddcol_insert values (2);
+--select * from t_zaddcol_insert;
+--insert into t_zaddcol_insert values (3,3);
+--select b from t_zaddcol_insert;


### PR DESCRIPTION
@hlinnaka opening this as PR for visiblity and discuss the options for handling alter table. Worked with Melanie on the same. The case to handle *not all the columns have TID present*, poses lot of complexity in code, as this PR can reflect. Based on same I am thinking seems better to not create this exception for zedstore, instead always have TID present in all the columns. Means don't use the heap table optimization to store the value in catalog instead add the column to table and write the column with TID for the same.

This PR currenlty handles selects after alter table add column with default value (without any following inserts). Handling selects followed by inserts seems will make code much more dirty/complex as during sequential scans if don't get the datum for TID same as other columns, then fill the value from catalog, etc.. Some how not liking this code.

    To accomplish the stated objective following code has been added.
    
    In the case of ALTER TABLE ADD COLUMN with a DEFAULT value, a btree is
    not created for the column, as there is no data to store. The default
    value is stored in catalog in pg_attribute.
    
    Assumption was all the columns have data for all the tuples. This
    doesn't hold true given above fact.
    
    So, when scanning the table, it's problematic if we assume that we
    will be able to determine the number of rows from any attribute in the
    table. Thus, we have to ensure that the columns being projected from a
    scan will include at least one column which has all the TIDs in table.
    Which can be used to determine the expected number of rows for all of
    the columns. Dropped columns are similarly invalid, as they are not
    guaranteed to have the same number of rows as are active columns.
    
    Function to fetch and fill missing attributes from the catalog
    zsbt_fill_missing_attribute_value() is being added. This is called by
    zedstore AM layer to fill in missing values for table. So, unlike
    heap, for zedstore, executor doesn't need to fill these values.
    
    btree scan callers use the tid for flow control.  btree scans set
    isvaluemissing to indicate to the caller that it cannot rely on the
    tid and now must use isvaluemissing flag for flow control.
    
    Co-authored-by: Melanie Plageman <mplageman@pivotal.io>
