### PR TITLE
WIP: speculative insert works

### DIFF
--- a/src/backend/access/zedstore/zedstore_visibility.c
+++ b/src/backend/access/zedstore/zedstore_visibility.c
@@ -450,7 +450,7 @@ zs_SatisfiesDirty(ZSBtreeScan *scan, ZSBtreeItem *item)
 	Assert (snapshot->snapshot_type == SNAPSHOT_DIRTY);
 
 	snapshot->xmin = snapshot->xmax = InvalidTransactionId;
-	snapshot->speculativeToken = 0;
+	snapshot->speculativeToken = INVALID_SPECULATIVE_TOKEN;
 
 	undo_ptr = zsbt_item_undoptr(item);
 
@@ -463,6 +463,7 @@ fetch_undo_record:
 
 	if (undorec->type == ZSUNDO_TYPE_INSERT)
 	{
+		snapshot->speculativeToken = undorec->speculative_token;
 		/* Inserted tuple */
 		if (TransactionIdIsCurrentTransactionId(undorec->xid))
 			return true;		/* inserted by me */

--- a/src/backend/access/zedstore/zedstoream_handler.c
+++ b/src/backend/access/zedstore/zedstoream_handler.c
@@ -760,6 +760,8 @@ zedstoream_update(Relation relation, ItemPointer otid_p, TupleTableSlot *slot,
 
 	ZSUndoRecPtrInitialize(&prevundoptr);
 
+	*update_indexes = true;
+
 	slot_getallattrs(slot);
 	d = slot->tts_values;
 	isnulls = slot->tts_isnull;

--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -474,7 +474,7 @@ struct zs_split_stack
 /* prototypes for functions in zedstore_btree.c */
 extern void zsbt_multi_insert(Relation rel, AttrNumber attno,
 							  Datum *datums, bool *isnulls, zstid *tids, int ndatums,
-							  TransactionId xid, CommandId cid, ZSUndoRecPtr prevundoptr);
+							  TransactionId xid, CommandId cid, uint32 speculative_token, ZSUndoRecPtr prevundoptr);
 extern TM_Result zsbt_delete(Relation rel, AttrNumber attno, zstid tid,
 							 TransactionId xid, CommandId cid,
 							 Snapshot snapshot, Snapshot crosscheck, bool wait,
@@ -603,6 +603,7 @@ extern Datum zedstore_toast_datum(Relation rel, AttrNumber attno, Datum value);
 extern void zedstore_toast_finish(Relation rel, AttrNumber attno, Datum toasted, zstid tid);
 extern Datum zedstore_toast_flatten(Relation rel, AttrNumber attno, zstid tid, Datum toasted);
 
+extern void zsbt_clear_speculative_token(Relation rel, zstid tid, uint32 spectoken, bool forcomplete);
 /* prototypes for functions in zedstore_freepagemap.c */
 extern Buffer zspage_getnewbuf(Relation rel, Buffer metabuf);
 extern Buffer zspage_extendrel_newbuf(Relation rel);

--- a/src/include/access/zedstore_undo.h
+++ b/src/include/access/zedstore_undo.h
@@ -39,6 +39,8 @@ typedef struct
 /* TODO: assert that blkno and offset match, too, if counter matches */
 #define ZSUndoRecPtrEquals(a, b) ((a).counter == (b).counter)
 
+#define INVALID_SPECULATIVE_TOKEN 0
+
 typedef struct
 {
 	int16		size;			/* size of this record, including header */
@@ -47,6 +49,7 @@ typedef struct
 	TransactionId xid;
 	CommandId	cid;
 	zstid		tid;
+	uint32		speculative_token; /* Only used for INSERT records */
 
 	/*
 	 * UNDO-record of the inserter. This is needed if a row is inserted, and
@@ -158,6 +161,7 @@ IsZSUndoRecPtrValid(ZSUndoRecPtr *uptr)
 /* prototypes for functions in zstore_undo.c */
 extern ZSUndoRecPtr zsundo_insert(Relation rel, ZSUndoRec *rec);
 extern ZSUndoRec *zsundo_fetch(Relation rel, ZSUndoRecPtr undorecptr);
+extern void zsundo_clear_speculative_token(Relation rel, ZSUndoRecPtr undoptr);
 extern void zsundo_vacuum(Relation rel, VacuumParams *params, BufferAccessStrategy bstrategy,
 			  TransactionId OldestXmin);
 extern ZSUndoRecPtr zsundo_get_oldest_undo_ptr(Relation rel);


### PR DESCRIPTION
    Speculative insert works for zedstore
    
    Previously, an insert with an `on conflict do update` would error out
    with an error that `zedstoream_insert_speculative` was not implemented
    yet. To implement it, perform the insert, get the tid from the tuple
    table slot, and then find the meta column item for the attribute which
    was updated and set the speculative insert token in its flags to true.
    
    Once the insert is completed, the speculative insert token is cleared
    from the meta column item for the updated attribute.
    
    Note that in the case that there is a conflict with a committed tuple,
    we don't follow the speculative insert codepath and instead call
    `ExecOnConflictUpdate`.  This means that for an insert with an `on
    conflict do update` which conflicts with an existing tuple, we don't
    exercise the speculative insert code.
    
    Once we have done the speculative insertion, there are situations in
    which we could still encounter a conflict. Exercising that code with
    zedstore is a TO-DO. So, error out in these cases.
    
    Also a TO-DO: this PR is WIP because I need to figure out what needs to
    be done, if anything with the speculative token.