### PR TITLE
Concurrent copy fix and associated refactoring

### DIFF
--- a/src/backend/access/zedstore/zedstore_btree.c
+++ b/src/backend/access/zedstore/zedstore_btree.c
@@ -315,6 +315,8 @@ zsbt_newroot(Relation rel, AttrNumber attno, int level, List *downlinks)
 	ListCell   *lc;
 	int			i;
 
+	Assert(downlinks->length == 2);
+
 	newrootbuf = zspage_getnewbuf(rel);
 
 	metabuf = ReadBuffer(rel, ZS_META_BLK);
@@ -427,7 +429,7 @@ zsbt_insert_downlinks(Relation rel, AttrNumber attno,
 	if (itemno < 0 || items[itemno].tid != leftlokey ||
 		items[itemno].childblk != leftblkno)
 	{
-		elog(PANIC, "could not find downlink for block %u TID (%u, %u)",
+		elog(ERROR, "could not find downlink for block %u TID (%u, %u)",
 			 leftblkno, ZSTidGetBlockNumber(leftlokey),
 			 ZSTidGetOffsetNumber(leftlokey));
 	}

--- a/src/backend/access/zedstore/zedstore_btree.c
+++ b/src/backend/access/zedstore/zedstore_btree.c
@@ -788,7 +788,7 @@ zs_new_split_stack_entry(Buffer buf, Page page)
 	return stack;
 }
 
-#define MAX_BLOCKS_IN_REWRITE		100
+#define MAX_BLOCKS_IN_REWRITE		199
 
 /*
  * Apply all the changes represented by a list of zs_split_stack

--- a/src/backend/access/zedstore/zedstore_btree.c
+++ b/src/backend/access/zedstore/zedstore_btree.c
@@ -427,7 +427,7 @@ zsbt_insert_downlinks(Relation rel, AttrNumber attno,
 	if (itemno < 0 || items[itemno].tid != leftlokey ||
 		items[itemno].childblk != leftblkno)
 	{
-		elog(ERROR, "could not find downlink for block %u TID (%u, %u)",
+		elog(PANIC, "could not find downlink for block %u TID (%u, %u)",
 			 leftblkno, ZSTidGetBlockNumber(leftlokey),
 			 ZSTidGetOffsetNumber(leftlokey));
 	}

--- a/src/include/access/xlogrecord.h
+++ b/src/include/access/xlogrecord.h
@@ -218,7 +218,7 @@ typedef struct XLogRecordDataHeaderLong
  * need a handful of block references, but there are a few exceptions that
  * need more.
  */
-#define XLR_MAX_BLOCK_ID			32
+#define XLR_MAX_BLOCK_ID			199
 
 #define XLR_BLOCK_ID_DATA_SHORT		255
 #define XLR_BLOCK_ID_DATA_LONG		254

--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -927,7 +927,9 @@ extern void merge_attstream_buffer(Form_pg_attribute attr, attstream_buffer *buf
 extern bool append_attstream_inplace(Form_pg_attribute att, ZSAttStream *oldstream, int freespace, attstream_buffer *newstream);
 
 extern int find_attstream_chop_pos(Form_pg_attribute att, char *chunks, int len, zstid *lasttid);
+extern int find_attstream_chop_pos_with_tid(attstream_buffer *attbuf, zstid splittid, zstid *lasttid);
 extern void chop_attstream(attstream_buffer *buffer, int pos, zstid lasttid);
+extern void chop_attstream_at_splittid(attstream_buffer *oldattbuf, attstream_buffer *newattbuf, zstid splittid);
 
 extern void print_attstream(int attlen, char *chunk, int len);
 

--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -926,10 +926,10 @@ extern void merge_attstream_buffer(Form_pg_attribute attr, attstream_buffer *buf
 
 extern bool append_attstream_inplace(Form_pg_attribute att, ZSAttStream *oldstream, int freespace, attstream_buffer *newstream);
 
-extern int find_attstream_chop_pos(Form_pg_attribute att, char *chunks, int len, zstid *lasttid);
-extern int find_attstream_chop_pos_with_tid(attstream_buffer *attbuf, zstid splittid, zstid *lasttid);
-extern void chop_attstream(attstream_buffer *buffer, int pos, zstid lasttid);
-extern void chop_attstream_at_splittid(attstream_buffer *oldattbuf, attstream_buffer *newattbuf, zstid splittid);
+extern int find_chunk_for_offset(attstream_buffer *attbuf, int offset, zstid *lasttid);
+extern int find_chunk_containing_tid(attstream_buffer *attbuf, zstid tid, zstid *lasttid);
+extern void trim_attstream_upto_offset(attstream_buffer *buf, int chunk_pos, zstid prev_lasttid);
+extern void split_attstream_buffer(attstream_buffer *oldattbuf, attstream_buffer *newattbuf, zstid splittid);
 
 extern void print_attstream(int attlen, char *chunk, int len);
 


### PR DESCRIPTION
This fixes the following concurrent copy bug:

```
could not find downlink for block 1298 TID (24671, 112)
```

This is because we always assumed that we insert new attributes to the
rightmost attribute tree leaf page. Consider the following scenario:
Session 1: Insert with tids = {1000..1999, 3000..3999}
Session 2: Insert with tids = {2000..2999, 4000..4999}

Note: The TID interleaving we see above is due to the way we assign
TIDs in blocks of 1000 in the table_multi_insert API. Session 1 gets the
block 1000-1999, then session 2 gets 2000-2999 and so on.

In session 1 we descend the attribute tree to reach the leaf page with
the key range: [90, MaxPlusOneZSTid). At that point, we find that that page is
full and we need to split. So say we split the page into P1 and P2 with
the ranges: [90, 3500) and [3500, MaxPlusOneZSTid) with the tids in
session 1 inserted into the respective pages. Now, for session 2 we
descend the tree with key = 2000 and we reach P1. Say, P1 has space.
Since we don't check if the lasttid in our attstream actually belongs to
the page, we end up inserting 2000..4999 all into P1.
Note that:

i) Even though the hikey for P1 is 3500, we end up inserting upto 4999.
ii) P1 now has an overlapping tid range with P2.

To fix this situation: Every time we try to flush the attstream buffer
to an attribute leaf page, we need to make sure that the lasttid in the
attstream buffer is smaller than the hikey of the target page. If it is
not smaller, then we need to split the attstream buffer at a splittid =
hikey_target_page - 1. Then we can proceed to insert the tids in the two
pages that is the result of the split, respecting the tid ranges of the
new pages.

Also we refactor around the fix:
* More comments for function interface expectations as well as
commentary for long routines.
* Make offset calculations more explicit.
* Assertions to make assumptions clearer.