### PR TITLE
Fix vpath build bug

### DIFF
--- a/src/test/regress/GNUmakefile
+++ b/src/test/regress/GNUmakefile
@@ -49,9 +49,9 @@ $(top_builddir)/src/port/pg_config_paths.h: | submake-libpgport
 
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_regress$(X) '$(DESTDIR)$(pgxsdir)/$(subdir)/pg_regress$(X)'
-	$(INSTALL_PROGRAM) gpdiff.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/gpdiff.pl'
-	$(INSTALL_PROGRAM) atmsort.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pl'
-	$(INSTALL_PROGRAM) atmsort.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
+	$(INSTALL_PROGRAM) $(srcdir)/gpdiff.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/gpdiff.pl'
+	$(INSTALL_PROGRAM) $(srcdir)/atmsort.pl '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pl'
+	$(INSTALL_PROGRAM) $(srcdir)/atmsort.pm '$(DESTDIR)$(pgxsdir)/$(subdir)/atmsort.pm'
 
 installdirs:
 	$(MKDIR_P) '$(DESTDIR)$(pgxsdir)/$(subdir)'


### PR DESCRIPTION
When I use vpath to build zedstore, as follows:

```
$ cd zedstore && mkdir Debug && cd Debug
$ ../configure --prefix=$PWD/zedstore --with-lz4
$ make && make install
```
Here is an error:

```
make[3]: Leaving directory '/home/japin/Codes/zedstore/Debug/contrib/spi'
/bin/mkdir -p '/home/japin/Codes/zedstore/Debug/zs/lib/postgresql/pgxs/src/test/regress'
/usr/bin/install -c  pg_regress '/home/japin/Codes/zedstore/Debug/zs/lib/postgresql/pgxs/src/test/regress/pg_regress'
/usr/bin/install -c  gpdiff.pl '/home/japin/Codes/zedstore/Debug/zs/lib/postgresql/pgxs/src/test/regress/gpdiff.pl'
/usr/bin/install: cannot stat 'gpdiff.pl': No such file or directory
GNUmakefile:51: recipe for target 'install' failed
make[2]: *** [install] Error 1
make[2]: Leaving directory '/home/japin/Codes/zedstore/Debug/src/test/regress'
Makefile:42: recipe for target 'install-test/regress-recurse' failed
make[1]: *** [install-test/regress-recurse] Error 2
make[1]: Leaving directory '/home/japin/Codes/zedstore/Debug/src'
GNUmakefile:11: recipe for target 'install-src-recurse' failed
make: *** [install-src-recurse] Error 2
```

The commit fixes this issue.