### PR TITLE
Avoid tid fetch in zedstoream_tuple_satisfies_snapshot()

### DIFF
--- a/src/backend/access/zedstore/zedstore_tiditem.c
+++ b/src/backend/access/zedstore/zedstore_tiditem.c
@@ -64,10 +64,14 @@ zsbt_tid_item_unpack(ZSTidArrayItem *item, ZSTidItemIterator *iter)
 	slotwords_to_slotnos(slotwords, num_tids, iter->tid_undoslotnos);
 
 	/* also copy out the slots to the iterator */
-	iter->undoslots[ZSBT_OLD_UNDO_SLOT] = InvalidUndoPtr;
-	iter->undoslots[ZSBT_DEAD_UNDO_SLOT] = DeadUndoPtr;
+	InvalidateUndoVisibility(&iter->visi_infos[ZSBT_OLD_UNDO_SLOT]);
+	InvalidateUndoVisibility(&iter->visi_infos[ZSBT_DEAD_UNDO_SLOT]);
+	iter->visi_infos[ZSBT_DEAD_UNDO_SLOT].undoptr = DeadUndoPtr;
 	for (int i = ZSBT_FIRST_NORMAL_UNDO_SLOT; i < item->t_num_undo_slots; i++)
-		iter->undoslots[i] = slots[i - ZSBT_FIRST_NORMAL_UNDO_SLOT];
+	{
+		InvalidateUndoVisibility(&iter->visi_infos[i]);
+		iter->visi_infos[i].undoptr = slots[i - ZSBT_FIRST_NORMAL_UNDO_SLOT];
+	}
 }
 
 /*

--- a/src/backend/access/zedstore/zedstore_tupslot.c
+++ b/src/backend/access/zedstore/zedstore_tupslot.c
@@ -26,7 +26,6 @@ tts_zedstore_init(TupleTableSlot *slot)
 {
 	ZedstoreTupleTableSlot *zslot = (ZedstoreTupleTableSlot *) slot;
 	zslot->visi_info = NULL;
-	zslot->undoRecPtr = InvalidUndoPtr;
 }
 
 static void
@@ -51,7 +50,6 @@ tts_zedstore_clear(TupleTableSlot *slot)
 	ItemPointerSetInvalid(&slot->tts_tid);
 
 	zslot->visi_info = NULL;
-	zslot->undoRecPtr = InvalidUndoPtr;
 }
 
 /*
@@ -219,12 +217,10 @@ tts_zedstore_copyslot(TupleTableSlot *dstslot, TupleTableSlot *srcslot)
 	if (srcslot->tts_ops == &TTSOpsZedstore)
 	{
 		zdstslot->visi_info = ((ZedstoreTupleTableSlot *) srcslot)->visi_info;
-		zdstslot->undoRecPtr = ((ZedstoreTupleTableSlot *) srcslot)->undoRecPtr;
 	}
 	else
 	{
 		zdstslot->visi_info = NULL;
-		zdstslot->undoRecPtr = InvalidUndoPtr;
 	}
 
 	dstslot->tts_nvalid = srcdesc->natts;

--- a/src/backend/access/zedstore/zedstore_tupslot.c
+++ b/src/backend/access/zedstore/zedstore_tupslot.c
@@ -26,6 +26,7 @@ tts_zedstore_init(TupleTableSlot *slot)
 {
 	ZedstoreTupleTableSlot *zslot = (ZedstoreTupleTableSlot *) slot;
 	zslot->visi_info = NULL;
+	zslot->undoRecPtr = InvalidUndoPtr;
 }
 
 static void
@@ -50,6 +51,7 @@ tts_zedstore_clear(TupleTableSlot *slot)
 	ItemPointerSetInvalid(&slot->tts_tid);
 
 	zslot->visi_info = NULL;
+	zslot->undoRecPtr = InvalidUndoPtr;
 }
 
 /*
@@ -215,9 +217,15 @@ tts_zedstore_copyslot(TupleTableSlot *dstslot, TupleTableSlot *srcslot)
 	}
 
 	if (srcslot->tts_ops == &TTSOpsZedstore)
+	{
 		zdstslot->visi_info = ((ZedstoreTupleTableSlot *) srcslot)->visi_info;
+		zdstslot->undoRecPtr = ((ZedstoreTupleTableSlot *) srcslot)->undoRecPtr;
+	}
 	else
+	{
 		zdstslot->visi_info = NULL;
+		zdstslot->undoRecPtr = InvalidUndoPtr;
+	}
 
 	dstslot->tts_nvalid = srcdesc->natts;
 	dstslot->tts_flags &= ~TTS_FLAG_EMPTY;

--- a/src/include/access/zedstore_internal.h
+++ b/src/include/access/zedstore_internal.h
@@ -889,7 +889,8 @@ extern TM_Result zsbt_tid_lock(Relation rel, zstid tid,
 							   LockTupleMode lockmode, bool follow_updates,
 							   Snapshot snapshot, TM_FailureData *hufd,
 							   zstid *next_tid, bool *this_xact_has_lock,
-							   ZSUndoSlotVisibility *visi_info);
+							   ZSUndoSlotVisibility *visi_info,
+							   ZSUndoRecPtr *undoRecPtr);
 extern void zsbt_tid_undo_deletion(Relation rel, zstid tid, ZSUndoRecPtr undoptr, ZSUndoRecPtr recent_oldest_undo);
 extern zstid zsbt_get_first_tid(Relation rel);
 extern zstid zsbt_get_last_tid(Relation rel);
@@ -1078,6 +1079,8 @@ typedef struct ZedstoreTupleTableSlot
 	 * fill in 'visi_info_buf', and set visi_info = &visi_info_buf.
 	 */
 	ZSUndoSlotVisibility visi_info_buf;
+
+	ZSUndoRecPtr undoRecPtr;
 } ZedstoreTupleTableSlot;
 
 #endif							/* ZEDSTORE_INTERNAL_H */


### PR DESCRIPTION
This addresses the following TODO in `zedstoream_tuple_satisfies_snapshot()`:
```
/*
 * TODO: we didn't keep any visibility information about the tuple in the
 * slot, so we have to fetch it again. A custom slot type might be a
 * good idea..
 */
```
We have kept visibility information in `ZedstoreTupleTableSlot` since
1d996afef9. We now make use of that info to call
`zs_SatisfiesVisibility()` instead of having to scan. To call this, we do
need the undoPtr for the tuple. So, we add this undoPtr to the slot,
wherever we supply the slot's visibility information.