### PR TITLE
Fetch only the columns that are required for a row fetch by tid

### DIFF
--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -181,7 +181,8 @@ static bool
 heapam_fetch_row_version(Relation relation,
 						 ItemPointer tid,
 						 Snapshot snapshot,
-						 TupleTableSlot *slot)
+						 TupleTableSlot *slot,
+						 Bitmapset *project_cols)
 {
 	BufferHeapTupleTableSlot *bslot = (BufferHeapTupleTableSlot *) slot;
 	Buffer		buffer;

--- a/src/backend/access/heap/heapam_handler.c
+++ b/src/backend/access/heap/heapam_handler.c
@@ -350,7 +350,7 @@ static TM_Result
 heapam_tuple_lock(Relation relation, ItemPointer tid, Snapshot snapshot,
 				  TupleTableSlot *slot, CommandId cid, LockTupleMode mode,
 				  LockWaitPolicy wait_policy, uint8 flags,
-				  TM_FailureData *tmfd)
+				  TM_FailureData *tmfd, Bitmapset *project_cols)
 {
 	BufferHeapTupleTableSlot *bslot = (BufferHeapTupleTableSlot *) slot;
 	TM_Result	result;

--- a/src/backend/access/zedstore/zedstoream_handler.c
+++ b/src/backend/access/zedstore/zedstoream_handler.c
@@ -457,7 +457,8 @@ static TM_Result
 zedstoream_lock_tuple(Relation relation, ItemPointer tid_p, Snapshot snapshot,
 					  TupleTableSlot *slot, CommandId cid, LockTupleMode mode,
 					  LockWaitPolicy wait_policy, uint8 flags,
-					  TM_FailureData *tmfd)
+					  TM_FailureData *tmfd,
+					  Bitmapset *project_cols)
 {
 	zstid		tid = ZSTidFromItemPointer(*tid_p);
 	TransactionId xid = GetCurrentTransactionId();
@@ -663,7 +664,7 @@ retry:
 
 	/* Fetch the tuple, too. */
 	if (!zedstoream_fetch_row_version(relation, tid_p, SnapshotAny, slot,
-									  get_ordinal_attnos(relation)))
+									  project_cols))
 		elog(ERROR, "could not fetch locked tuple");
 
 	return TM_Ok;

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2984,7 +2984,8 @@ GetTupleForTrigger(EState *estate,
 								estate->es_output_cid,
 								lockmode, LockWaitBlock,
 								lockflags,
-								&tmfd);
+								&tmfd,
+								get_ordinal_attnos(relation));
 
 		switch (test)
 		{

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -3059,7 +3059,7 @@ GetTupleForTrigger(EState *estate,
 		 * suffices.
 		 */
 		if (!table_tuple_fetch_row_version(relation, tid, SnapshotAny,
-										   oldslot))
+										   oldslot, NULL))
 			elog(ERROR, "failed to fetch tuple for trigger");
 	}
 
@@ -3921,7 +3921,7 @@ AfterTriggerExecute(EState *estate,
 
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid1),
 												   SnapshotAny,
-												   LocTriggerData.tg_trigslot))
+												   LocTriggerData.tg_trigslot, NULL))
 					elog(ERROR, "failed to fetch tuple1 for AFTER trigger");
 				LocTriggerData.tg_trigtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_trigslot, false, &should_free_trig);
@@ -3940,7 +3940,7 @@ AfterTriggerExecute(EState *estate,
 
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid2),
 												   SnapshotAny,
-												   LocTriggerData.tg_newslot))
+												   LocTriggerData.tg_newslot, NULL))
 					elog(ERROR, "failed to fetch tuple2 for AFTER trigger");
 				LocTriggerData.tg_newtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_newslot, false, &should_free_new);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -3059,7 +3059,7 @@ GetTupleForTrigger(EState *estate,
 		 * suffices.
 		 */
 		if (!table_tuple_fetch_row_version(relation, tid, SnapshotAny,
-										   oldslot, NULL))
+										   oldslot, get_ordinal_attnos(relation)))
 			elog(ERROR, "failed to fetch tuple for trigger");
 	}
 
@@ -3921,7 +3921,8 @@ AfterTriggerExecute(EState *estate,
 
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid1),
 												   SnapshotAny,
-												   LocTriggerData.tg_trigslot, NULL))
+												   LocTriggerData.tg_trigslot,
+												   get_ordinal_attnos(rel)))
 					elog(ERROR, "failed to fetch tuple1 for AFTER trigger");
 				LocTriggerData.tg_trigtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_trigslot, false, &should_free_trig);
@@ -3940,7 +3941,8 @@ AfterTriggerExecute(EState *estate,
 
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid2),
 												   SnapshotAny,
-												   LocTriggerData.tg_newslot, NULL))
+												   LocTriggerData.tg_newslot,
+												   get_ordinal_attnos(rel)))
 					elog(ERROR, "failed to fetch tuple2 for AFTER trigger");
 				LocTriggerData.tg_newtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_newslot, false, &should_free_new);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2985,7 +2985,7 @@ GetTupleForTrigger(EState *estate,
 								lockmode, LockWaitBlock,
 								lockflags,
 								&tmfd,
-								get_ordinal_attnos(relation));
+								bms_make_singleton(0));
 
 		switch (test)
 		{
@@ -3060,7 +3060,7 @@ GetTupleForTrigger(EState *estate,
 		 * suffices.
 		 */
 		if (!table_tuple_fetch_row_version(relation, tid, SnapshotAny,
-										   oldslot, get_ordinal_attnos(relation)))
+										   oldslot, bms_make_singleton(0)))
 			elog(ERROR, "failed to fetch tuple for trigger");
 	}
 
@@ -3923,7 +3923,7 @@ AfterTriggerExecute(EState *estate,
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid1),
 												   SnapshotAny,
 												   LocTriggerData.tg_trigslot,
-												   get_ordinal_attnos(rel)))
+												   bms_make_singleton(0)))
 					elog(ERROR, "failed to fetch tuple1 for AFTER trigger");
 				LocTriggerData.tg_trigtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_trigslot, false, &should_free_trig);
@@ -3943,7 +3943,7 @@ AfterTriggerExecute(EState *estate,
 				if (!table_tuple_fetch_row_version(rel, &(event->ate_ctid2),
 												   SnapshotAny,
 												   LocTriggerData.tg_newslot,
-												   get_ordinal_attnos(rel)))
+												   bms_make_singleton(0)))
 					elog(ERROR, "failed to fetch tuple2 for AFTER trigger");
 				LocTriggerData.tg_newtuple =
 					ExecFetchSlotHeapTuple(LocTriggerData.tg_newslot, false, &should_free_new);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2647,7 +2647,7 @@ EvalPlanQualFetchRowMark(EPQState *epqstate, Index rti, TupleTableSlot *slot)
 			/* ordinary table, fetch the tuple */
 			if (!table_tuple_fetch_row_version(erm->relation,
 											   (ItemPointer) DatumGetPointer(datum),
-											   SnapshotAny, slot))
+											   SnapshotAny, slot, NULL))
 				elog(ERROR, "failed to fetch tuple for EvalPlanQual recheck");
 			return true;
 		}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2648,7 +2648,7 @@ EvalPlanQualFetchRowMark(EPQState *epqstate, Index rti, TupleTableSlot *slot)
 			if (!table_tuple_fetch_row_version(erm->relation,
 											   (ItemPointer) DatumGetPointer(datum),
 											   SnapshotAny, slot,
-											   get_ordinal_attnos(erm->relation)))
+											   bms_make_singleton(0)))
 				elog(ERROR, "failed to fetch tuple for EvalPlanQual recheck");
 			return true;
 		}

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -2647,7 +2647,8 @@ EvalPlanQualFetchRowMark(EPQState *epqstate, Index rti, TupleTableSlot *slot)
 			/* ordinary table, fetch the tuple */
 			if (!table_tuple_fetch_row_version(erm->relation,
 											   (ItemPointer) DatumGetPointer(datum),
-											   SnapshotAny, slot, NULL))
+											   SnapshotAny, slot,
+											   get_ordinal_attnos(erm->relation)))
 				elog(ERROR, "failed to fetch tuple for EvalPlanQual recheck");
 			return true;
 		}

--- a/src/backend/executor/execPartition.c
+++ b/src/backend/executor/execPartition.c
@@ -847,6 +847,8 @@ ExecInitPartitionInfo(ModifyTableState *mtstate, EState *estate,
 						ExecInitQual((List *) clause, &mtstate->ps);
 				}
 			}
+
+			PopulateNeededColumnsForOnConflictUpdate(leaf_part_rri);
 		}
 	}
 

--- a/src/backend/executor/execReplication.c
+++ b/src/backend/executor/execReplication.c
@@ -119,7 +119,8 @@ bool
 RelationFindReplTupleByIndex(Relation rel, Oid idxoid,
 							 LockTupleMode lockmode,
 							 TupleTableSlot *searchslot,
-							 TupleTableSlot *outslot)
+							 TupleTableSlot *outslot,
+							 Bitmapset *project_cols)
 {
 	ScanKeyData skey[INDEX_MAX_KEYS];
 	IndexScanDesc scan;
@@ -179,7 +180,8 @@ retry:
 							   lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
-							   &tmfd);
+							   &tmfd,
+							   project_cols);
 
 		PopActiveSnapshot();
 
@@ -285,7 +287,8 @@ tuples_equal(TupleTableSlot *slot1, TupleTableSlot *slot2)
  */
 bool
 RelationFindReplTupleSeq(Relation rel, LockTupleMode lockmode,
-						 TupleTableSlot *searchslot, TupleTableSlot *outslot)
+						 TupleTableSlot *searchslot, TupleTableSlot *outslot,
+						 Bitmapset *project_cols)
 {
 	TupleTableSlot *scanslot;
 	TableScanDesc scan;
@@ -346,7 +349,8 @@ retry:
 							   lockmode,
 							   LockWaitBlock,
 							   0 /* don't follow updates */ ,
-							   &tmfd);
+							   &tmfd,
+							   project_cols);
 
 		PopActiveSnapshot();
 

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -118,7 +118,10 @@ IndexNext(IndexScanState *node)
 		if (table_scans_leverage_column_projection(node->ss.ss_currentRelation))
 		{
 			Bitmapset *proj = NULL;
-			proj = PopulateNeededColumnsForScan(&node->ss, node->ss.ss_currentRelation->rd_att->natts);
+			Scan *planNode = (Scan *)node->ss.ps.plan;
+			int rti = planNode->scanrelid;
+			RangeTblEntry *rte = list_nth(estate->es_plannedstmt->rtable, rti - 1);
+			proj = rte->scanCols;
 			table_index_fetch_set_column_projection(scandesc->xs_heapfetch, proj);
 		}
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -236,7 +236,7 @@ ExecCheckTIDVisible(EState *estate,
 	if (!IsolationUsesXactSnapshot())
 		return;
 
-	if (!table_tuple_fetch_row_version(rel, tid, SnapshotAny, tempSlot))
+	if (!table_tuple_fetch_row_version(rel, tid, SnapshotAny, tempSlot, NULL))
 		elog(ERROR, "failed to fetch conflicting tuple for ON CONFLICT");
 	ExecCheckTupleVisible(estate, rel, tempSlot);
 	ExecClearTuple(tempSlot);
@@ -1014,8 +1014,10 @@ ldelete:;
 			}
 			else
 			{
+				RangeTblEntry *resultrte = exec_rt_fetch(resultRelInfo->ri_RangeTableIndex, estate);
 				if (!table_tuple_fetch_row_version(resultRelationDesc, tupleid,
-												   SnapshotAny, slot))
+												   SnapshotAny, slot,
+												   resultrte->returningCols))
 					elog(ERROR, "failed to fetch deleted tuple for DELETE RETURNING");
 			}
 		}

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1015,6 +1015,15 @@ ldelete:;
 			else
 			{
 				RangeTblEntry *resultrte = exec_rt_fetch(resultRelInfo->ri_RangeTableIndex, estate);
+				/*
+				 * XXX returningCols should never be empty if we have a RETURNING
+				 * clause. Right now, if we have a view, we fail to populate the
+				 * returningCols of it's base table's RTE.
+				 * If we encounter such a situation now, for correctness, ensure
+				 * that we fetch all the columns.
+				 */
+				if(bms_is_empty(resultrte->returningCols))
+					resultrte->returningCols = get_ordinal_attnos(resultRelationDesc);
 				if (!table_tuple_fetch_row_version(resultRelationDesc, tupleid,
 												   SnapshotAny, slot,
 												   resultrte->returningCols))

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -71,11 +71,13 @@ SeqNext(SeqScanState *node)
 		 */
 		if (table_scans_leverage_column_projection(node->ss.ss_currentRelation))
 		{
-			Bitmapset *proj = PopulateNeededColumnsForScan(&node->ss,
-														   node->ss.ss_currentRelation->rd_att->natts);
+			Scan *planNode = (Scan *)node->ss.ps.plan;
+			int rti = planNode->scanrelid;
+			RangeTblEntry *rte = list_nth(estate->es_plannedstmt->rtable, rti - 1);
 			scandesc = table_beginscan_with_column_projection(node->ss.ss_currentRelation,
 															  estate->es_snapshot,
-															  0, NULL, proj);
+															  0, NULL,
+															  rte->scanCols);
 		}
 		else
 		{

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -375,7 +375,7 @@ TidNext(TidScanState *node)
 		if (node->tss_isCurrentOf)
 			table_tuple_get_latest_tid(scan, &tid);
 
-		if (table_tuple_fetch_row_version(heapRelation, &tid, snapshot, slot))
+		if (table_tuple_fetch_row_version(heapRelation, &tid, snapshot, slot, NULL))
 			return slot;
 
 		/* Bad TID or failed snapshot qual; try next */

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2402,6 +2402,7 @@ _copyRangeTblEntry(const RangeTblEntry *from)
 	COPY_BITMAPSET_FIELD(returningCols);
 	COPY_BITMAPSET_FIELD(updatedCols);
 	COPY_BITMAPSET_FIELD(extraUpdatedCols);
+	COPY_BITMAPSET_FIELD(scanCols);
 	COPY_NODE_FIELD(securityQuals);
 
 	return newnode;

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2399,6 +2399,7 @@ _copyRangeTblEntry(const RangeTblEntry *from)
 	COPY_SCALAR_FIELD(checkAsUser);
 	COPY_BITMAPSET_FIELD(selectedCols);
 	COPY_BITMAPSET_FIELD(insertedCols);
+	COPY_BITMAPSET_FIELD(returningCols);
 	COPY_BITMAPSET_FIELD(updatedCols);
 	COPY_BITMAPSET_FIELD(extraUpdatedCols);
 	COPY_NODE_FIELD(securityQuals);

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2698,6 +2698,7 @@ _equalRangeTblEntry(const RangeTblEntry *a, const RangeTblEntry *b)
 	COMPARE_BITMAPSET_FIELD(returningCols);
 	COMPARE_BITMAPSET_FIELD(updatedCols);
 	COMPARE_BITMAPSET_FIELD(extraUpdatedCols);
+	COMPARE_BITMAPSET_FIELD(scanCols);
 	COMPARE_NODE_FIELD(securityQuals);
 
 	return true;

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -2695,6 +2695,7 @@ _equalRangeTblEntry(const RangeTblEntry *a, const RangeTblEntry *b)
 	COMPARE_SCALAR_FIELD(checkAsUser);
 	COMPARE_BITMAPSET_FIELD(selectedCols);
 	COMPARE_BITMAPSET_FIELD(insertedCols);
+	COMPARE_BITMAPSET_FIELD(returningCols);
 	COMPARE_BITMAPSET_FIELD(updatedCols);
 	COMPARE_BITMAPSET_FIELD(extraUpdatedCols);
 	COMPARE_NODE_FIELD(securityQuals);

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3126,6 +3126,7 @@ _outRangeTblEntry(StringInfo str, const RangeTblEntry *node)
 	WRITE_BITMAPSET_FIELD(returningCols);
 	WRITE_BITMAPSET_FIELD(updatedCols);
 	WRITE_BITMAPSET_FIELD(extraUpdatedCols);
+	WRITE_BITMAPSET_FIELD(scanCols);
 	WRITE_NODE_FIELD(securityQuals);
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -3123,6 +3123,7 @@ _outRangeTblEntry(StringInfo str, const RangeTblEntry *node)
 	WRITE_OID_FIELD(checkAsUser);
 	WRITE_BITMAPSET_FIELD(selectedCols);
 	WRITE_BITMAPSET_FIELD(insertedCols);
+	WRITE_BITMAPSET_FIELD(returningCols);
 	WRITE_BITMAPSET_FIELD(updatedCols);
 	WRITE_BITMAPSET_FIELD(extraUpdatedCols);
 	WRITE_NODE_FIELD(securityQuals);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1462,6 +1462,7 @@ _readRangeTblEntry(void)
 	READ_BITMAPSET_FIELD(returningCols);
 	READ_BITMAPSET_FIELD(updatedCols);
 	READ_BITMAPSET_FIELD(extraUpdatedCols);
+	READ_BITMAPSET_FIELD(scanCols);
 	READ_NODE_FIELD(securityQuals);
 
 	READ_DONE();

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -1459,6 +1459,7 @@ _readRangeTblEntry(void)
 	READ_OID_FIELD(checkAsUser);
 	READ_BITMAPSET_FIELD(selectedCols);
 	READ_BITMAPSET_FIELD(insertedCols);
+	READ_BITMAPSET_FIELD(returningCols);
 	READ_BITMAPSET_FIELD(updatedCols);
 	READ_BITMAPSET_FIELD(extraUpdatedCols);
 	READ_NODE_FIELD(securityQuals);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2421,7 +2421,8 @@ transformReturningList(ParseState *pstate, Query *qry, List *returningList)
 			/*
 			 * If there is a whole-row var, we have to fetch the whole row.
 			 */
-			rte->returningCols = get_ordinal_attnos(pstate->p_target_relation);
+			bms_free(rte->returningCols);
+			rte->returningCols = bms_make_singleton(0);
 			break;
 		}
 	}

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2421,9 +2421,7 @@ transformReturningList(ParseState *pstate, Query *qry, List *returningList)
 			/*
 			 * If there is a whole-row var, we have to fetch the whole row.
 			 */
-			TupleDesc tupleDesc = RelationGetDescr(pstate->p_target_relation);
-			for (int attno = 1; attno <= tupleDesc->natts; attno++)
-				bms_add_member(rte->returningCols, attno);
+			rte->returningCols = get_ordinal_attnos(pstate->p_target_relation);
 			break;
 		}
 	}

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1451,6 +1451,7 @@ addRangeTableEntry(ParseState *pstate,
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
 	rte->updatedCols = NULL;
+	rte->returningCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
 	/*
@@ -1538,6 +1539,7 @@ addRangeTableEntryForRelation(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;	/* not set-uid by default, either */
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -1635,6 +1637,7 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -1911,6 +1914,7 @@ addRangeTableEntryForFunction(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -1982,6 +1986,7 @@ addRangeTableEntryForTableFunc(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -2069,6 +2074,7 @@ addRangeTableEntryForValues(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -2158,6 +2164,7 @@ addRangeTableEntryForJoin(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -2277,6 +2284,7 @@ addRangeTableEntryForCTE(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
@@ -2392,6 +2400,7 @@ addRangeTableEntryForENR(ParseState *pstate,
 	rte->requiredPerms = 0;
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
+	rte->returningCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1453,6 +1453,7 @@ addRangeTableEntry(ParseState *pstate,
 	rte->updatedCols = NULL;
 	rte->returningCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -1541,6 +1542,7 @@ addRangeTableEntryForRelation(ParseState *pstate,
 	rte->insertedCols = NULL;
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
+	rte->scanCols = NULL;
 	rte->extraUpdatedCols = NULL;
 
 	/*
@@ -1640,6 +1642,7 @@ addRangeTableEntryForSubquery(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -1917,6 +1920,7 @@ addRangeTableEntryForFunction(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -1989,6 +1993,7 @@ addRangeTableEntryForTableFunc(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -2077,6 +2082,7 @@ addRangeTableEntryForValues(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -2167,6 +2173,7 @@ addRangeTableEntryForJoin(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -2287,6 +2294,7 @@ addRangeTableEntryForCTE(ParseState *pstate,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its
@@ -2401,6 +2409,7 @@ addRangeTableEntryForENR(ParseState *pstate,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->returningCols = NULL;
+	rte->scanCols = NULL;
 
 	/*
 	 * Add completed RTE to pstate's range table list, so that we know its

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -1640,6 +1640,7 @@ ApplyRetrieveRule(Query *parsetree,
 			rte->checkAsUser = InvalidOid;
 			rte->selectedCols = NULL;
 			rte->insertedCols = NULL;
+			rte->returningCols = NULL;
 			rte->updatedCols = NULL;
 
 			/*
@@ -1740,6 +1741,7 @@ ApplyRetrieveRule(Query *parsetree,
 	subrte->checkAsUser = rte->checkAsUser;
 	subrte->selectedCols = rte->selectedCols;
 	subrte->insertedCols = rte->insertedCols;
+	subrte->returningCols = rte->returningCols;
 	subrte->updatedCols = rte->updatedCols;
 	subrte->extraUpdatedCols = rte->extraUpdatedCols;
 
@@ -1747,6 +1749,7 @@ ApplyRetrieveRule(Query *parsetree,
 	rte->checkAsUser = InvalidOid;
 	rte->selectedCols = NULL;
 	rte->insertedCols = NULL;
+	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
 

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -1642,6 +1642,7 @@ ApplyRetrieveRule(Query *parsetree,
 			rte->insertedCols = NULL;
 			rte->returningCols = NULL;
 			rte->updatedCols = NULL;
+			rte->scanCols = NULL;
 
 			/*
 			 * For the most part, Vars referencing the view should remain as
@@ -1744,6 +1745,7 @@ ApplyRetrieveRule(Query *parsetree,
 	subrte->returningCols = rte->returningCols;
 	subrte->updatedCols = rte->updatedCols;
 	subrte->extraUpdatedCols = rte->extraUpdatedCols;
+	subrte->scanCols = rte->scanCols;
 
 	rte->requiredPerms = 0;		/* no permission check on subquery itself */
 	rte->checkAsUser = InvalidOid;
@@ -1752,6 +1754,7 @@ ApplyRetrieveRule(Query *parsetree,
 	rte->returningCols = NULL;
 	rte->updatedCols = NULL;
 	rte->extraUpdatedCols = NULL;
+	rte->scanCols = NULL;
 
 	return parsetree;
 }

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -3085,6 +3085,7 @@ rewriteTargetView(Query *parsetree, Relation view)
 	 * base_rte instead of copying it.
 	 */
 	new_rte = base_rte;
+	new_rte->returningCols = bms_copy(view_rte->returningCols);
 	new_rte->rellockmode = RowExclusiveLock;
 
 	parsetree->rtable = lappend(parsetree->rtable, new_rte);
@@ -3437,6 +3438,7 @@ rewriteTargetView(Query *parsetree, Relation view)
 		}
 	}
 
+	new_rte->returningCols = bms_copy(view_rte->returningCols);
 	table_close(base_rel, NoLock);
 
 	return parsetree;

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -482,7 +482,8 @@ typedef struct TableAmRoutine
 							   LockTupleMode mode,
 							   LockWaitPolicy wait_policy,
 							   uint8 flags,
-							   TM_FailureData *tmfd);
+							   TM_FailureData *tmfd,
+							   Bitmapset *project_cols);
 
 	/*
 	 * Perform operations necessary to complete insertions made via
@@ -1440,11 +1441,11 @@ static inline TM_Result
 table_tuple_lock(Relation rel, ItemPointer tid, Snapshot snapshot,
 				 TupleTableSlot *slot, CommandId cid, LockTupleMode mode,
 				 LockWaitPolicy wait_policy, uint8 flags,
-				 TM_FailureData *tmfd)
+				 TM_FailureData *tmfd, Bitmapset *project_cols)
 {
 	return rel->rd_tableam->tuple_lock(rel, tid, snapshot, slot,
 									   cid, mode, wait_policy,
-									   flags, tmfd);
+									   flags, tmfd, project_cols);
 }
 
 /*

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -1165,14 +1165,6 @@ table_tuple_fetch_row_version(Relation rel,
 	return rel->rd_tableam->tuple_fetch_row_version(rel, tid, snapshot, slot, project_cols);
 }
 
-static inline Bitmapset *
-get_ordinal_attnos(Relation rel)
-{
-	Bitmapset *attnos = NULL;
-	attnos = bms_add_range(attnos, 1, RelationGetDescr(rel)->natts);
-	return attnos;
-}
-
 /*
  * Verify that `tid` is a potentially valid tuple identifier. That doesn't
  * mean that the pointed to row needs to exist or be visible, but that

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -393,7 +393,8 @@ typedef struct TableAmRoutine
 	bool		(*tuple_fetch_row_version) (Relation rel,
 											ItemPointer tid,
 											Snapshot snapshot,
-											TupleTableSlot *slot);
+											TupleTableSlot *slot,
+											Bitmapset *project_cols);
 
 	/*
 	 * Is tid valid for a scan of this relation.
@@ -1158,9 +1159,10 @@ static inline bool
 table_tuple_fetch_row_version(Relation rel,
 							  ItemPointer tid,
 							  Snapshot snapshot,
-							  TupleTableSlot *slot)
+							  TupleTableSlot *slot,
+							  Bitmapset *project_cols)
 {
-	return rel->rd_tableam->tuple_fetch_row_version(rel, tid, snapshot, slot);
+	return rel->rd_tableam->tuple_fetch_row_version(rel, tid, snapshot, slot, project_cols);
 }
 
 /*

--- a/src/include/access/tableam.h
+++ b/src/include/access/tableam.h
@@ -1165,6 +1165,14 @@ table_tuple_fetch_row_version(Relation rel,
 	return rel->rd_tableam->tuple_fetch_row_version(rel, tid, snapshot, slot, project_cols);
 }
 
+static inline Bitmapset *
+get_ordinal_attnos(Relation rel)
+{
+	Bitmapset *attnos = NULL;
+	attnos = bms_add_range(attnos, 1, RelationGetDescr(rel)->natts);
+	return attnos;
+}
+
 /*
  * Verify that `tid` is a potentially valid tuple identifier. That doesn't
  * mean that the pointed to row needs to exist or be visible, but that

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -588,9 +588,11 @@ extern void check_exclusion_constraint(Relation heap, Relation index,
 extern bool RelationFindReplTupleByIndex(Relation rel, Oid idxoid,
 										 LockTupleMode lockmode,
 										 TupleTableSlot *searchslot,
-										 TupleTableSlot *outslot);
+										 TupleTableSlot *outslot,
+										 Bitmapset *project_cols);
 extern bool RelationFindReplTupleSeq(Relation rel, LockTupleMode lockmode,
-									 TupleTableSlot *searchslot, TupleTableSlot *outslot);
+									 TupleTableSlot *searchslot, TupleTableSlot *outslot,
+									 Bitmapset *project_cols);
 
 extern void ExecSimpleRelationInsert(EState *estate, TupleTableSlot *slot);
 extern void ExecSimpleRelationUpdate(EState *estate, EPQState *epqstate,
@@ -605,5 +607,7 @@ extern void
 PopulateNeededColumnsForNode(Node *expr, int n, Bitmapset **scanCols);
 extern Bitmapset *
 PopulateNeededColumnsForScan(ScanState *scanstate, int ncol);
+extern Bitmapset *PopulateNeededColumnsForEPQ(EPQState *epqstate, int ncol);
+extern void PopulateNeededColumnsForOnConflictUpdate(ResultRelInfo *resultRelInfo);
 
 #endif							/* EXECUTOR_H  */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -384,6 +384,7 @@ typedef struct OnConflictSetState
 	TupleTableSlot *oc_ProjSlot;	/* CONFLICT ... SET ... projection target */
 	ProjectionInfo *oc_ProjInfo;	/* for ON CONFLICT DO UPDATE SET */
 	ExprState  *oc_WhereClause; /* state for the WHERE clause */
+	Bitmapset *proj_cols; /* cols to be scanned during the operation */
 } OnConflictSetState;
 
 /*

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1118,6 +1118,7 @@ typedef struct RangeTblEntry
 	Oid			checkAsUser;	/* if valid, check access as this role */
 	Bitmapset  *selectedCols;	/* columns needing SELECT permission */
 	Bitmapset  *insertedCols;	/* columns needing INSERT permission */
+	Bitmapset  *returningCols;  /* columns in the RETURNING clause */
 	Bitmapset  *updatedCols;	/* columns needing UPDATE permission */
 	Bitmapset  *extraUpdatedCols;	/* generated columns being updated */
 	List	   *securityQuals;	/* security barrier quals to apply, if any */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1121,6 +1121,12 @@ typedef struct RangeTblEntry
 	Bitmapset  *returningCols;  /* columns in the RETURNING clause */
 	Bitmapset  *updatedCols;	/* columns needing UPDATE permission */
 	Bitmapset  *extraUpdatedCols;	/* generated columns being updated */
+	/*
+	 * Columns to be scanned.
+	 * If the 0th element is set due to varattno == 0
+	 * that means all columns must be scanned, so handle this at scan-time
+	 */
+	Bitmapset  *scanCols;
 	List	   *securityQuals;	/* security barrier quals to apply, if any */
 } RangeTblEntry;
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1118,16 +1118,23 @@ typedef struct RangeTblEntry
 	Oid			checkAsUser;	/* if valid, check access as this role */
 	Bitmapset  *selectedCols;	/* columns needing SELECT permission */
 	Bitmapset  *insertedCols;	/* columns needing INSERT permission */
-	Bitmapset  *returningCols;  /* columns in the RETURNING clause */
 	Bitmapset  *updatedCols;	/* columns needing UPDATE permission */
 	Bitmapset  *extraUpdatedCols;	/* generated columns being updated */
-	/*
-	 * Columns to be scanned.
-	 * If the 0th element is set due to varattno == 0
-	 * that means all columns must be scanned, so handle this at scan-time
-	 */
-	Bitmapset  *scanCols;
 	List	   *securityQuals;	/* security barrier quals to apply, if any */
+
+	/*
+	 * scanCols: Columns to be retrieved during a physical scan.
+	 * returningCols: Columns to be retrieved to satisfy the RETURNING clause.
+	 *
+	 * Please note: These bitmaps only deal with non-system columns (attnum >= 0)
+	 *
+	 * These bitmaps have some special values:
+	 * - A singleton bitmap with the element 0 indicates that all non-system
+	 *   columns must be fetched.
+	 * - An empty bitmap indicates that no non-system column must be fetched.
+	 */
+	Bitmapset  *scanCols;		/* columns to be fetched during a physical scan */
+	Bitmapset  *returningCols;	/* columns in the RETURNING clause */
 } RangeTblEntry;
 
 /*

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -615,6 +615,14 @@ typedef struct ViewOptions
 	 RelationNeedsWAL(relation) && \
 	 !IsCatalogRelation(relation))
 
+static inline Bitmapset *
+get_ordinal_attnos(Relation rel)
+{
+	Bitmapset *attnos = NULL;
+	attnos = bms_add_range(attnos, 1, RelationGetDescr(rel)->natts);
+	return attnos;
+}
+
 /* routines in utils/cache/relcache.c */
 extern void RelationIncrementReferenceCount(Relation rel);
 extern void RelationDecrementReferenceCount(Relation rel);

--- a/src/include/utils/rel.h
+++ b/src/include/utils/rel.h
@@ -615,6 +615,12 @@ typedef struct ViewOptions
 	 RelationNeedsWAL(relation) && \
 	 !IsCatalogRelation(relation))
 
+static inline bool
+contains_whole_row_col(Bitmapset *cols)
+{
+	return bms_is_member(0, cols);
+}
+
 static inline Bitmapset *
 get_ordinal_attnos(Relation rel)
 {

--- a/src/test/storageperf/sql/dml.sql
+++ b/src/test/storageperf/sql/dml.sql
@@ -1,0 +1,110 @@
+DROP TABLE IF EXISTS public.wide_table;
+CREATE TABLE public.wide_table(i int, j int, k int, l int, m int, n int, o int);
+INSERT INTO public.wide_table SELECT g, g+1, g+2, g+3, g+4, g+5, g+6 FROM generate_series(1, 100000) g;
+
+-- DELETE
+
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "BEGIN; DELETE FROM public.wide_table WHERE i >= 1; ROLLBACK;" > /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t40 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, DELETE',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);
+
+-- DELETE RETURNING
+
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "BEGIN; DELETE FROM public.wide_table WHERE i >= 1 RETURNING j; ROLLBACK;" > /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t40 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, DELETE RETURNING',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);
+
+-- UPSERT
+CREATE UNIQUE INDEX wide_table_i ON public.wide_table(i);
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "BEGIN; INSERT INTO public.wide_table SELECT g FROM generate_series(1, 100000) g ON CONFLICT (i) DO UPDATE SET j=-1, k=-1, l=-1, m=-1, n=-1, o=-1 WHERE public.wide_table.k>=1; ROLLBACK;" > /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t5 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, UPSERT',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);
+DROP INDEX public.wide_table_i;
+
+-- ON CONFLICT DO NOTHING
+CREATE UNIQUE INDEX wide_table_i ON public.wide_table(i);
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "INSERT INTO public.wide_table SELECT g FROM generate_series(1, 100000) g ON CONFLICT (i) DO NOTHING;" > /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t5 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, ON CONFLICT DO NOTHING',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);
+DROP INDEX public.wide_table_i;
+
+-- Tid scans
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "SET enable_seqscan TO off;" > /tmp/dml-pgbench-script.sql
+
+\! echo "EXPLAIN ANALYZE SELECT i FROM wide_table WHERE ctid IN (SELECT ctid from wide_table);" >> /tmp/dml-pgbench-script.sql
+
+\! echo "RESET enable_seqscan;" >> /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t5 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, TidScan',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);
+
+-- Row level locking
+
+select pg_current_wal_insert_lsn() as wal_before, extract(epoch from now()) as time_before
+\gset
+
+\! echo "SELECT i FROM wide_table WHERE j >= 100 FOR UPDATE;" > /tmp/dml-pgbench-script.sql
+
+\! pgbench -n -c 1 -t10 -f /tmp/dml-pgbench-script.sql postgres
+
+select pg_current_wal_insert_lsn() as wal_after, extract(epoch from now()) as time_after
+\gset
+INSERT INTO results (testname, size, walsize, time)
+VALUES ('dml, pgbench, Row level locking',
+        pg_total_relation_size('public.wide_table'),
+        :'wal_after'::pg_lsn - :'wal_before',
+        :time_after - :time_before);

--- a/src/test/storageperf/tests.sql
+++ b/src/test/storageperf/tests.sql
@@ -5,3 +5,4 @@
 \i sql/lockperf.sql
 \i sql/inlinecompress.sql
 \i sql/toast.sql
+\i sql/dml.sql


### PR DESCRIPTION
This will be a patch set comprised of:
1. Patch to extract the set of RETURNING columns for a I/U/D operation.
2. Passing sets of columns to the table AM routine `tuple_fetch_row_version()` from each of its callers:
a) Satisfying the RETURNING clause for a DELETE query.
b) Tid scans.
c) More...
3. Passes a list of columns to `tuple_lock()` (which is in many ways similar to `tuple_fetch_row_version()` that it fetches a row given a tid).